### PR TITLE
Functions with parameters and the pop operation

### DIFF
--- a/Lang.hs
+++ b/Lang.hs
@@ -3,7 +3,6 @@
 -- Cole Swanson
 -- Melanie Gutzmann
 
-
 module StackLang where
 
 
@@ -38,8 +37,6 @@ type Prog = [Cmd]
 
 type FuncName = String
 
--- functions can take parameters simply by calling functions like 'pop' on the stack,
--- which will return the first value to the calling function
 type Func = (FuncName, [Cmd])
 
 type Domain = Stack -> [Func] -> Maybe Stack

--- a/Lang.hs
+++ b/Lang.hs
@@ -18,6 +18,7 @@ data Expr = Add
           | Equ
           | If Prog Prog
           | Less
+          | Call FuncName
    deriving (Eq, Show)
 
 data Stmt = While Expr Cmd
@@ -25,6 +26,7 @@ data Stmt = While Expr Cmd
    deriving (Eq, Show)
 
 data Cmd = Push Value
+         | Pop
          | E Expr
          | S Stmt
    deriving (Eq, Show)
@@ -33,12 +35,22 @@ type Stack = [Value]
 
 type Prog = [Cmd]
 
+type FuncName = String
+
+-- functions can take parameters simply by calling functions like 'pop' on the stack,
+-- which will return the first value to the calling function
+type Func = (FuncName, [Cmd])
+
 type Domain = Stack -> Maybe Stack
 
-cmd :: Cmd -> Domain
-cmd (Push v) q = Just (v : q)
-cmd (E e)    q = expr e q
-cmd (S s)    q = stmt s q
+cmd :: [Func] -> Cmd -> Stack -> (Maybe Stack, Maybe Value)
+cmd _  (Pop) []     = (Nothing, Nothing)
+cmd _  (Pop) (q:qs) = (Just qs, Just q)
+cmd _  (Push v)  q  = (Just (v : q), Nothing)
+cmd fs (E e)     q  = (expr fs e q, Nothing)
+cmd fs (S s)     q  = (stmt fs s q, Nothing)
+
+
 
 safeDiv :: Int -> Int -> Maybe Int
 safeDiv _ 0 = Nothing
@@ -70,94 +82,101 @@ tupleLess (T a b) (T c d) = case (a, b, c, d) of
 tupleLess _       _       = False
 
 
-expr :: Expr -> Domain
-expr Add q = case q of 
+expr :: [Func] -> Expr -> Domain
+expr fs Add q = case q of 
                 (I i   : I j   : qs) -> Just (I (i + j) : qs)
-                ( F f : qs )         -> case (prog [f] qs) of 
-                                        Just q  -> expr Add q
+                ( F f : qs )         -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Add q
                                         Nothing -> Nothing  
-                (a : F f : qs )      -> case (prog [f] qs) of 
-                                        Just q  -> expr Add (a : q)
+                (a : F f : qs )      -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Add (a : q)
                                         Nothing -> Nothing  
                 (T v w : T y z : qs) -> case (v, w, y, z) of
                                           (I v, I w, I y, I z) -> Just (T (I (v + y)) (I (w + z)) : qs)
                                           _                    -> Nothing
                 _                    -> Nothing
-expr Mul q = case q of
+expr fs Mul q = case q of
                 (I i   : I j   : qs) -> Just (I (i * j) : qs)
-                ( F f : qs )         -> case (prog [f] qs) of 
-                                        Just q  -> expr Mul q
+                ( F f : qs )         -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Mul q
                                         Nothing -> Nothing 
-                (a : F f : qs )      -> case (prog [f] qs) of 
-                                        Just q  -> expr Mul (a : q)
+                (a : F f : qs )      -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Mul (a : q)
                                         Nothing -> Nothing   
                 (T v w : T y z : qs) -> case (v, w, y, z) of
                                           (I v, I w, I y, I z) -> Just (T (I (v * y)) (I (w * z)) : qs)
                                           _                    -> Nothing
                 _                    -> Nothing
-expr Div q = case q of
+expr fs Div q = case q of
                (I i   : I j   : qs) -> case safeDiv i j of
                                        (Just k) -> Just (I k : qs)
                                        _        -> Nothing
-               ( F f : qs )         -> case (prog [f] qs) of 
-                                       Just q  -> expr Div q
+               ( F f : qs )         -> case (prog fs [f] qs) of 
+                                       Just q  -> expr fs Div q
                                        Nothing -> Nothing
-               (a : F f : qs )      -> case (prog [f] qs) of 
-                                        Just q  -> expr Div (a : q)
+               (a : F f : qs )      -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Div (a : q)
                                         Nothing -> Nothing  
                (T v w : T y z : qs) -> case tupleDiv (T v w) (T y z) of
                                           (Just (T a b)) -> Just (T a b : qs)
                                           _              -> Nothing
                _                    -> Nothing
-expr Equ q = case q of 
+expr fs Equ q = case q of 
                (I i   : I j   : qs) -> Just (B (i == j) : qs)
                (B a   : B b   : qs) -> Just (B (a == b) : qs)
-               ( F f : qs )         -> case (prog [f] qs) of 
-                                       Just q  -> expr Equ q
+               ( F f : qs )         -> case (prog fs [f] qs) of 
+                                       Just q  -> expr fs Equ q
                                        Nothing -> Nothing
-               (a : F f : qs )      -> case (prog [f] qs) of 
-                                        Just q  -> expr Equ (a : q)
+               (a : F f : qs )      -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Equ (a : q)
                                         Nothing -> Nothing  
                (T v w : T y z : qs) -> Just (B (tupleEqu (T v w) (T y z)) : qs)
                _                    -> Nothing
-expr Less q = case q of 
+expr fs Less q = case q of 
                (I i   : I j   : qs) -> Just (B (i < j) : qs)
-               ( F f : qs )         -> case (prog [f] qs) of 
-                                       Just q  -> expr Less q
+               ( F f : qs )         -> case (prog fs [f] qs) of 
+                                       Just q  -> expr fs Less q
                                        Nothing -> Nothing
-               (a : F f : qs )      -> case (prog [f] qs) of 
-                                        Just q  -> expr Less (a : q)
+               (a : F f : qs )      -> case (prog fs [f] qs) of 
+                                        Just q  -> expr fs Less (a : q)
                                         Nothing -> Nothing  
                (T v w : T y z : qs) -> Just (B (tupleLess (T v w) (T y z)) : qs) 
                _                    -> Nothing                
-expr (If t f) q = case q of
-                  (B True : qs)  -> prog t qs
-                  (B False : qs) -> prog f qs
-                  (F func : qs)  -> case (prog [func] qs) of
-                                    Just q  -> expr (If t f) q
+expr fs (If t f) q = case q of
+                  (B True : qs)  -> prog fs t qs
+                  (B False : qs) -> prog fs f qs
+                  (F func : qs)  -> case (prog fs [func] qs) of
+                                    Just q  -> expr fs (If t f) q
                                     Nothing -> Nothing
                   _              -> Nothing 
+expr fs (Call fn) q = case lookupFunc fn fs of 
+                              Just cmds -> prog fs cmds q
+                              _         -> Nothing
 
-stmt :: Stmt -> Domain
-stmt (While e c) q = case (expr e q) of 
-                     (Just ((B True):qs)) -> case (cmd c qs) of
-                                             (Just q) -> stmt (While e c) q
+stmt :: [Func] -> Stmt -> Domain
+stmt fs (While e c) q = case (expr fs e q) of 
+                     (Just ((B True):qs)) -> case (cmd fs c qs) of
+                                             (Just q, _ ) -> stmt fs (While e c) q
                                              _        -> Nothing
                      (Just (_:qs))        -> Just (qs)
                      _                    -> Nothing
-stmt (Begin (c:cs)) q = case (cmd c q) of
-                           (Just q) -> stmt (Begin cs) q
+stmt fs (Begin (c:cs)) q = case (cmd fs c q) of
+                           (Just q, _) -> stmt fs (Begin cs) q
                            _        -> Nothing
-stmt (Begin []) q = Just q
+stmt _ (Begin []) q = Just q
  
+-- Takes the name of a function and a list of functions, and returns the list of commands associated
+-- with the function, if it exists. If the function doesn't exist, it returns Nothing.
+lookupFunc :: FuncName -> [Func] -> Maybe [Cmd]
+lookupFunc fn []             = Nothing
+lookupFunc fn ((n, cmds):fs) = if n == fn then Just cmds
+                               else lookupFunc fn fs
 
-
-prog :: Prog -> Domain
-prog [] q      = Just q
-prog (c:cs) q  = case cmd c q of
-                     (Just q) -> prog cs q 
-                     _        -> Nothing
-
+prog :: [Func] -> Prog -> Domain
+prog  _     []  q  = Just q
+prog  fs (c:cs) q  = case cmd fs c q of
+                              (Just q, _) -> prog fs cs q 
+                              _           -> Nothing
 
 -- Syntactic Sugar --
 


### PR DESCRIPTION
Added the ability to define named functions that are able to take parameters. Also implemented the pop operator. In order to store function names, I had to introduce a kind of "environment" to our domain -- it's now `type Domain = Stack -> [Func] -> Maybe Stack`.

The new syntax for a "prog" is:
```
prog <main function> <stack to be called on> <list of other functions>
````
where the `<list of other functions>` is a list of tuples of the form ("NameOfFunction", [Cmd]).

## Examples
Define a function called `pushProg` that pushes `4` onto the stack. The program calls it onto an empty stack. `notUsedFunc` is to demonstrate that extra functions can be defined without being called.
```
>>>  prog [Call "pushProg"] [] [("pushProg", [Push (I 4)]), ("notUsedFunc", [])]
Just [I 4]
```

Define a function called `pushProg` that pushes `4` onto the stack. The program first adds `4` and `5` together (here I just put them in the starter stack, but they could be `Push`ed on as well), then calls the function.
```
>>> prog [E Add, Call "pushProg"] [I 4, I 5] [("pushProg", [Push (I 4)])]
Just [I 4,I 9]
```

Here's a function that actually does something semi-useful in pseudocode and its translation into MathLang:
```
def mystery(a, b, c) {
    if ((a*b) > c) {
         return True
    }
    else {
         return False
     }
}

mystery(1, 5, 7)
```
```
>>> prog [Push (I 7), Push (I 5), Push (I 1), Call "mystery"] [] [("mystery", [E Mul, E Less, notl])]
Just [B False]
```

Functions can also be called within each other!
```
>>> prog [Call "func1"] [] [("func2", [Push (I 3)]), ("func1", [Call "func2", Push (I 4)])]
Just [I 4,I 3]
```