### PR TITLE
Implement CallStackFunc (functions as arguments) and Factorials

### DIFF
--- a/Lang.hs
+++ b/Lang.hs
@@ -11,7 +11,6 @@ data Value = I Int
            | T Value Value
            | C Cmd 
            | F FuncName
-           | Null
    deriving (Eq, Show)
 
 data Expr = Add

--- a/Lang.hs
+++ b/Lang.hs
@@ -11,6 +11,7 @@ data Value = I Int
            | T Value Value
            | C Cmd 
            | F FuncName
+           | Null
    deriving (Eq, Show)
 
 data Expr = Add
@@ -19,9 +20,12 @@ data Expr = Add
           | Equ
           | If Prog Prog
           | Less
+          | Dup
+          | ExprList [Expr]
+          | IsType
    deriving (Eq, Show)
 
-data Stmt = While Expr Cmd
+data Stmt = While Expr Prog
           | Begin Prog
    deriving (Eq, Show)
 
@@ -31,6 +35,7 @@ data Cmd = Push Value
          | S Stmt
          | Call FuncName
          | CallStackFunc
+         | Swap
    deriving (Eq, Show)
 
 type Stack = [Value]
@@ -52,11 +57,17 @@ cmd (S s)           q      fs = stmt s q fs
 cmd (Call fn)       q      fs = case lookupFunc fn fs of 
                                     Just cmds -> prog cmds q fs
                                     _         -> Nothing
+-- Allows functions to be passed from the stack to other functions.
 cmd (CallStackFunc) (q:qs) fs = case q of 
                                     (F fn) -> case lookupFunc fn fs of
                                                    Just cmds -> prog cmds qs fs
                                                    _         -> Nothing
                                     _      -> Nothing
+-- Swaps the position of the first two elements of the stack, if they exist
+cmd (Swap)           q     fs = case q of
+                                    []             -> Nothing
+                                    [q1]           -> Nothing
+                                    (q1 : q2 : qs) -> Just (q2 : q1 : qs)
 
 
 safeDiv :: Int -> Int -> Maybe Int
@@ -156,10 +167,33 @@ expr (If t f) q fs = case q of
                                     Just q  -> expr (If t f) q fs
                                     Nothing -> Nothing
                   _              -> Nothing 
+-- Duplicates the top value on the stack.
+expr (Dup) q fs = case q of 
+                     []      -> Just []
+                     (v:qs)  -> Just (v : v : qs)
+-- Represents a list of expressions to evaluate against the stack, in order.
+expr (ExprList el) q fs = case el of 
+                              []       -> Just q
+                              (e : es) -> case expr e q fs of
+                                             Just q2 -> expr (ExprList es) q2 fs
+                                             _       -> Nothing
+-- Checks if the top two values on the stack are the same type. Does not consume the values.
+expr (IsType) q fs = case q of 
+                            []             -> Nothing
+                            [v1]           -> Nothing
+                            (v1 : v2 : vs) -> case (v1, v2) of
+                                                   (I i1, I i2)       -> Just (B True  : q)
+                                                   (B i1, B i2)       -> Just (B True  : q)
+                                                   (T i1 i2, T i3 i4) -> Just (B True  : q)
+                                                   (C i1, C i2)       -> Just (B True  : q)
+                                                   (F i1, F i2)       -> Just (B True  : q)
+                                                   _                  -> Just (B False : q)
+
+
 
 stmt :: Stmt -> Domain
 stmt (While e c) q fs = case (expr e q fs) of 
-                     (Just ((B True):qs)) -> case (cmd c qs fs) of
+                     (Just ((B True):qs)) -> case (prog c qs fs) of
                                              Just q -> stmt (While e c) q fs
                                              _      -> Nothing
                      (Just (_:qs))        -> Just (qs)
@@ -168,6 +202,7 @@ stmt (Begin (c:cs)) q fs = case (cmd c q fs) of
                            Just q -> stmt (Begin cs) q fs
                            _      -> Nothing
 stmt (Begin []) q _ = Just q
+
  
 -- Takes the name of a function and a list of functions, and returns the list of commands associated
 -- with the function, if it exists. If the function doesn't exist, it returns Nothing.
@@ -190,8 +225,8 @@ true = Push (B True)
 false :: Cmd
 false = Push (B True)
 
-greaterequ :: Cmd
-greaterequ = S (Begin [E Less, notl])
+greaterequ :: Expr
+greaterequ = ExprList [Less, notl]
 
 inc :: Cmd
 inc = S (Begin [Push (I 1), E Add])
@@ -199,11 +234,26 @@ inc = S (Begin [Push (I 1), E Add])
 dec :: Cmd
 dec = S (Begin [Push (I (-1)), E Add])
 
-notl :: Cmd
-notl = E (If [Push (B False)] [Push (B True)])
+notl :: Expr
+notl = If [Push (B False)] [Push (B True)]
 
 andl :: Cmd
 andl = E (If [E (If [true] [false])] [E (If [false] [false])]) 
 
 orl :: Cmd
-orl = E (If [E (If [true] [true])] [E (If [true] [false])]) 
+orl = E (If [E (If [true] [true])] [E (If [true] [false])])
+
+minus :: Cmd
+minus = S (Begin [Push (I (-1)), E Mul, E Add])
+
+absval :: Cmd
+absval = S (Begin [E Dup, Push (I 0), E Less, E (If [] [Push (I (-1)), E Mul])])
+
+-- Library-level or possibly syntactic sugar?
+
+-- Factorial must be run by first providing a non-int value (any kind), and then the number itself. The non-int value will be consumed.
+-- For example, [Push (Null), Push (I 3), factorial] returns [I 6]
+factorial :: Cmd
+factorial = S (Begin [E Dup, Push (I 2), S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
+            S (While IsType [E Mul]), Swap, Pop ])
+

--- a/Lang.hs
+++ b/Lang.hs
@@ -250,9 +250,8 @@ absval = S (Begin [E Dup, Push (I 0), E Less, E (If [] [Push (I (-1)), E Mul])])
 
 -- Library-level or possibly syntactic sugar?
 
--- Factorial must be run by first providing a non-int value (any kind), and then the number itself. The non-int value will be consumed.
--- For example, [Push (Null), Push (I 3), factorial] returns [I 6]
 factorial :: Cmd
-factorial = S (Begin [E Dup, Push (I 2), S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
+factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2), 
+            S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
             S (While IsType [E Mul]), Swap, Pop ])
 


### PR DESCRIPTION
Closes #17 , #11 

Apologies in advance - I had to change/add quite a bit of things to get Factorial to work.

I realize there's like 3 pull requests still waiting to be merged ahead of this one; I'll try and get latest and clean up any merge issues once those are merged into main.

## CallStackFunc
Allows the passing of functions as arguments. See below example:

Calls "foo", which takes a function off the stack and executes it before adding 1. Here, the function it receives multiplies 4*5.
```
>>> prog [Push (I 4), Push (I 5), Push (F "product"), Call "foo"] [] [("foo", [CallStackFunc, Push (I 1), E Add]), ("product", [E Mul]), ("sum", [E Add])]
Just [I 21]
```

Calls "foo", which takes a function off the stack and executes it before adding 1. Here, the function it receives adds 4+5.
```
>>> prog [Push (I 4), Push (I 5), Push (F "sum"), Call "foo"] [] [("foo", [CallStackFunc, Push (I 1), E Add]), ("product", [E Mul]), ("sum", [E Add])]
Just [I 10]
```

**Noteworthy changes:** 
- Changed `Value = ... | F Cmd ` to be `Value = ... | C Cmd | F Funcname` since it seemed more appropriate.

## Factorial
I think I've got it implemented as syntactic sugar. It's pretty simple to use, just `prog [Push (I 6), factorial] [] []` which returns `Just [I 720]`.

**Things I had to implement/change to get it to work:**

- 3 new `Expr`, including `Dup` (duplicates first item on stack), `ExprList` (allows multiple `Expr` to be evaluated one after each other - see last bullet point), and `IsType` (checks if first two items on stack are of the same type).
- `data Stmt = While Expr Cmd` is now `data Stmt = While Expr Prog` ; it seemed appropriate that a while loop should be able to take an entire program, not just a single command, unless I'm misunderstanding how it's supposed to be used.
- 1 new `Cmd`: ` Swap`, which swaps the first two values of the stack. It's a bit of a silly command but I needed it to implement factorial. Hope it's ok if it stays.
- 2 new syntactic sugar bits: `minus` and `absval`, which are pretty straightforward.
- Finally, I had to change the format of some of the syntactic sugar pieces. Originally, they were all of type `Cmd`, but I found that if I wanted to do something like `While greaterequ [...]` I would get a type error because `greaterequ` was a `Cmd`, and not a `Expr` (as the `While Expr Prog` constructor requires). Obviously `while (!(a<b))` (2 stack operations: 1 for `a<b` and 1 for `!`) should still be just as valid as `while(a<b)` (1 stack operation - just `a < b`), but there was no way to represent a sequence of `Expr` without using `Cmd`s. So I created `ExprList`, which allows multiple `Expr` to condense into a single `Expr`.
