### PR TITLE
Adds a Good Example and changes factorial to a library-level function

### DIFF
--- a/MathLang.hs
+++ b/MathLang.hs
@@ -22,6 +22,7 @@ data Expr = Add
           | Dup
           | ExprList [Expr]
           | IsType
+          | Mod
    deriving (Eq, Show)
 
 data Stmt = While Expr Prog
@@ -188,7 +189,10 @@ expr (IsType) q fs = case q of
                                                    (C i1, C i2)       -> Just (B True  : q)
                                                    (F i1, F i2)       -> Just (B True  : q)
                                                    _                  -> Just (B False : q)
-
+expr (Mod) q fs = case q of 
+                        (I i : [])       -> Just ([I (1 `mod` i)])
+                        (I i : I j : qs) -> Just (I (j `mod` i) : qs)
+                        _                -> Nothing
 
 
 stmt :: Stmt -> Domain

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -282,4 +282,8 @@ factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2),
 
 -- Good example 1: deconstruct an integer into its digits
 example1 :: Prog
-example1 = [Push (I 3)]
+example1 = [Push (I 123567),
+            E Dup, Push (I 0), 
+            --S (While Less [E Dup, Push (I 10), E Mod, Swap, E Dup, Push (I 10), Swap, E Div, Push (I 0), Push (I 0)])]
+            S ( While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
+            Pop]

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -220,6 +220,11 @@ prog  (c:cs) q fs = case cmd c q fs of
                         Just q -> prog cs q fs
                         _      -> Nothing
 
+-- Runs a Prog on an empty stack and with no other functions declared.
+run :: Prog -> Maybe Stack
+run [] = prog [] [] []
+run x  = prog x [] []
+
 -- Syntactic Sugar --
 
 true :: Cmd
@@ -259,3 +264,6 @@ factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2),
             S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
             S (While IsType [E Mul]), Swap, Pop ])
 
+-- Good example 1: deconstruct an integer into its digits
+example1 :: Prog
+example1 = [Push (I 3)]

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -281,9 +281,11 @@ factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2),
             S (While IsType [E Mul]), Swap, Pop ])
 
 -- Good example 1: deconstruct an integer into its digits
+-- run using 'run example1' or for custom arguments 'prog deconstructint [I 2837] []`
 example1 :: Prog
-example1 = [Push (I 123567),
-            E Dup, Push (I 0), 
-            --S (While Less [E Dup, Push (I 10), E Mod, Swap, E Dup, Push (I 10), Swap, E Div, Push (I 0), Push (I 0)])]
-            S ( While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
-            Pop]
+example1 = [Push (I 235234)] ++ deconstructint
+
+deconstructint :: Prog
+deconstructint = [E Dup, Push (I 0), 
+                  S (While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
+                  Pop]

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -279,15 +279,20 @@ minus = S (Begin [Push (I (-1)), E Mul, E Add])
 absval :: Cmd
 absval = S (Begin [E Dup, Push (I 0), E Less, E (If [] [Push (I (-1)), E Mul])])
 
--- Good example 1: deconstruct an integer into its digits
--- run using 'run deconstructint_example deconstruct' or for custom arguments 'prog deconstructint [I 2837] deconstruct`
+-- Good Examples --
+
+-- Example 1: Deconstruct an integer into its digits.
+-- run using 'run deconstructint_example functions' or for custom arguments 'prog deconstructint [I 2837] functions`
 deconstructint_example :: Prog
 deconstructint_example = [Push (I 235234)] ++ deconstructint
 
 deconstructint :: Prog
-deconstructint = [E Dup, Push (I 0), 
+deconstructint = [Call "preprocessing",
                   S (While Less [Call "deconstruct"]),
-                  Pop]
+                  Push (F "cleanup"), CallStackFunc]
 
-deconstruct :: [Func]
-deconstruct = [("deconstruct", [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)])]
+functions :: [Func]
+functions = [  ("preprocessing", [E Dup, Push (I 0)]),
+               ("deconstruct", [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
+               ("cleanup", [Pop])
+            ]

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -5,6 +5,12 @@
 
 module MathLang where
 
+-- Our "Prelude", which contains library-level definitions
+mathlude :: [Func]
+mathlude = [("factorial", [S (Begin [Push (B False), Swap, E Dup, Push (I 2), 
+            S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
+            S (While IsType [E Mul]), Swap, Pop ])])
+           ]
 
 data Value = I Int
            | B Bool
@@ -236,10 +242,10 @@ prog  (c:cs) q fs = case cmd c q fs of
                         Just q -> prog cs q fs
                         _      -> Nothing
 
--- Runs a Prog on an empty stack and with no other functions declared.
-run :: Prog -> Maybe Stack
-run [] = prog [] [] []
-run x  = prog x [] []
+-- Runs a Prog with the MathLude
+run :: Prog -> [Func] -> Maybe Stack
+run [] fs = prog [] [] (fs ++ mathlude)
+run x  fs = prog x [] (fs ++ mathlude)
 
 -- Syntactic Sugar --
 
@@ -273,19 +279,15 @@ minus = S (Begin [Push (I (-1)), E Mul, E Add])
 absval :: Cmd
 absval = S (Begin [E Dup, Push (I 0), E Less, E (If [] [Push (I (-1)), E Mul])])
 
--- Library-level or possibly syntactic sugar?
-
-factorial :: Cmd
-factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2), 
-            S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
-            S (While IsType [E Mul]), Swap, Pop ])
-
 -- Good example 1: deconstruct an integer into its digits
--- run using 'run example1' or for custom arguments 'prog deconstructint [I 2837] []`
-example1 :: Prog
-example1 = [Push (I 235234)] ++ deconstructint
+-- run using 'run deconstructint_example deconstruct' or for custom arguments 'prog deconstructint [I 2837] deconstruct`
+deconstructint_example :: Prog
+deconstructint_example = [Push (I 235234)] ++ deconstructint
 
 deconstructint :: Prog
 deconstructint = [E Dup, Push (I 0), 
-                  S (While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
+                  S (While Less [Call "deconstruct"]),
                   Pop]
+
+deconstruct :: [Func]
+deconstruct = [("deconstruct", [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)])]

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -282,17 +282,17 @@ absval = S (Begin [E Dup, Push (I 0), E Less, E (If [] [Push (I (-1)), E Mul])])
 -- Good Examples --
 
 -- Example 1: Deconstruct an integer into its digits.
--- run using 'run deconstructint_example functions' or for custom arguments 'prog deconstructint [I 2837] functions`
-deconstructint_example :: Prog
-deconstructint_example = [Push (I 235234)] ++ deconstructint
+-- run using 'run int2digit_example i2d_functions' or for custom arguments 'prog int2digit_example [I 2837] i2d_functions`
+int2digit_example :: Prog
+int2digit_example = [Push (I 235234)] ++ int2digit
 
-deconstructint :: Prog
-deconstructint = [Call "preprocessing",
+int2digit :: Prog
+int2digit = [Call "preprocessing",
                   S (While Less [Call "deconstruct"]),
                   Push (F "cleanup"), CallStackFunc]
 
-functions :: [Func]
-functions = [  ("preprocessing", [E Dup, Push (I 0)]),
+i2d_functions :: [Func]
+i2d_functions = [  ("preprocessing", [E Dup, Push (I 0)]),
                ("deconstruct", [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]),
                ("cleanup", [Pop])
             ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ Our language, named _MathLang_, is a stack-based language with a stack that can 
 _MathLang_ is intended to be run from GHCi, so the _Lang_ module must be loaded to run programs in the language.
 
 ### Good Program Examples and their Outputs
+This program deconstructs an integer into its digits which are then pushed back onto the stack.
+```haskell
+-- Prebuilt example: (runs against empty stack)
+run deconstructint_example
+>>> Expected Output: Just [I 2,I 3,I 5,I 2,I 3,I 4]
+
+-- Custom arguments:
+prog deconstructint [I 2837] []
+>>> Expected Output: Just [I 2,I 8,I 3,I 7]
+
+-- Full program:
+prog [E Dup, Push (I 0), S (While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]), Pop] [I 2837] []
+>>> Expected Output: Just [I 2,I 8,I 3,I 7]
+```
+
 ```haskell
 cmd (Push (I 4)) []
 >>> Expected Output: Just [I 4]

--- a/README.md
+++ b/README.md
@@ -9,97 +9,39 @@ Cole Swanson     | swanscol
 Hannah Vaughan   | vaughanh
 
 ## Language Introduction
-Our language, named _MathLang_, is a stack-based language with a stack that can have integers, booleans, and tuples as its values. These values can be pushed onto the stack, and mathematical operations can be performed on the integer values in the stack. Conditional logic allows for differing series of commands to be executed with if/else branching; while loops allow for looping to occur on values on the stack, and tuples can be both constructed and deconstructed to provide invertability.
+Our language, named _MathLang_, is a stack-based language with a stack that can have integers, doubles, booleans, tuples, commands, and functions as its values. These values can be pushed onto the stack, and mathematical operations can be performed on the integer, boolean, and tuple values in the stack. Conditional logic allows for differing series of commands to be executed with if/else branching; while loops allow for looping to occur on values on the stack, and tuples can be both constructed and deconstructed to provide invertability. A "Mathlude" contains functions that perform less common mathematical operations, such as `factorial`, `percent`, and `summation`.
 
 ## Usage
 ### Setup Instructions
 _MathLang_ is intended to be run from GHCi, so the _Lang_ module must be loaded to run programs in the language.
 
 ### Good Program Examples and their Outputs
-This program deconstructs an integer into its digits which are then pushed back onto the stack.
+#### Example 1: Convert Integers to Digits
+This program deconstructs an integer into its digits. The digits are then pushed back onto the stack as individual integers.
 ```haskell
--- Prebuilt example: (runs against empty stack)
-run deconstructint_example
+-- Prebuilt example:
+run int2digit_example i2d_functions
 >>> Expected Output: Just [I 2,I 3,I 5,I 2,I 3,I 4]
 
--- Custom arguments:
-prog deconstructint [I 2837] []
+-- Custom argument:
+prog int2digit_example [I 2837] i2d_functions
 >>> Expected Output: Just [I 2,I 8,I 3,I 7]
 
 -- Full program:
-prog [E Dup, Push (I 0), S (While Less [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]), Pop] [I 2837] []
+prog [Call "preprocessing", S (While Less [Call "deconstruct"]), Push (F "cleanup"), CallStackFunc] [I 2837] [  ("preprocessing", [E Dup, Push (I 0)]), ("deconstruct", [E Dup, Push (I 10), E Mod, Swap, Push (I 10), Swap, E Div, E Dup, Push (I 0)]), ("cleanup", [Pop])]
 >>> Expected Output: Just [I 2,I 8,I 3,I 7]
 ```
 
-```haskell
-cmd (Push (I 4)) []
->>> Expected Output: Just [I 4]
-```
+#### Example 2: TBA
+
+#### Further Examples
+Further examples of programs written in our language can be found in our "Mathlude". This standard library contains functions that allow users of our language to perform mathmatical calculations. Users can call functions such as `factorial`, `summation`, and `percent`. These functions are automatically included in the list of accessible functions when programs are run using the `run` keyword.
 
 ```haskell
-cmd (Push (B True)) [I 4]
->>> Expected Output: Just [B True,I 4]
+run [Push (I 6), Call "factorial"] []
+>>> Expected Output: Just [I 720]
 ```
 
-```haskell
-cmd (Push (T (I 1) (B False))) [B True,I 4]
->>> Expected Output: Just [T (I 1) (B False),B True,I 4]
-```
-
-```haskell
-expr Add [I 2,I 3,I 8]
-cmd (E Add) [I 2,I 3,I 8]
->>> Expected Output: Just [I 5,I 8]
-```
-
-```haskell
-expr Add [T (I 1) (I 2),T (I 2) (I 3),T (I 20) (I 40)]
-cmd (E Add) [T (I 1) (I 2),T (I 2) (I 3),T (I 20) (I 40)]
->>> Expected Output: Just [T (I 3) (I 5),T (I 20) (I 40)]
-```
-
-```haskell
-expr Mul [I 2,I 3,I 8]
-cmd (E Mul) [I 2,I 3,I 8]
->>> Expected Output: Just [I 6,I 8]
-```
-
-```haskell
-expr Mul [T (I 2) (I 3),T (I 4) (I 5),T (I 20) (I 40)]
-cmd (E Mul) [T (I 2) (I 3),T (I 4) (I 5),T (I 20) (I 40)]
->>> Expected Output: Just [T (I 8) (I 15),T (I 20) (I 40)]
-```
-
-```haskell
-expr Div [I 10,I 5,I 8]
-cmd (E Div) [I 10,I 5,I 8]
->>> Expected Output: Just [I 2,I 8]
-```
-
-```haskell
-expr Equ [I 2,I 2,I 3]
->>> Expected Output: Just [B True,I 3]
-```
-
-```haskell
-expr Equ [B True,B False,I 3]
->>> Expected Output: Just [B False,I 3]
-```
-
-```haskell
-expr (If [Push (I 5)] [Push (B True)]) [B True]
->>> Expected Output: Just [I 5]
-```
-
-```haskell
-stmt (While Equ (S (Begin [Push (I 5),Push (I 2),E Add]))) [B True,B True]
->>> Expected Output: Just [I 7]
-```
-
-```haskell
-prog [Push (I 5),Push (I 2),E Add] []
->>> Expected Output: Just [I 7]
-```
 
 ### Bad Program Examples and their Outputs
 ```haskell

--- a/README.md
+++ b/README.md
@@ -43,7 +43,58 @@ run [Push (I 6), Call "factorial"] []
 ```
 
 
+### Bad Program Examples and their Outputs
+```haskell
+expr Add [I 1,B True,I 2]
+>>> Expected Output: Nothing
+```
 
+```haskell
+expr Mul [B False,I 1,I 2]
+>>> Expected Output: Nothing
+```
+
+```haskell
+expr Div [I 5,I 0,I 1]
+>>> Expected Output: Nothing
+```
+
+```haskell
+expr Div [I 5,B True,I 1]
+>>> Expected Output: Nothing
+```
+
+```haskell
+expr Equ [B True,T (B False) (B True)]
+>>> Expected Output: Nothing
+```
+
+```haskell
+expr (If [Push (I 5)] [Push (B False)]) [T (B True) (I 1)]
+>>> Expected Output: Nothing
+```
+
+```haskell
+stmt (While Equ [Push (I 5),E Add]) [B True,I 4]
+>>> Expected Output: Nothing
+```
+
+```haskell
+prog [E Add,E Equ] []
+>>> Expected Output: Nothing
+```
+
+```haskell
+cmd (ExtractTuple 5) [T (I 3) (I 4)] []
+>>> Expected Output: Nothing
+```
+
+```haskell
+cmd (ExtractTuple 1) [B True,T (B False) (I 4)] []
+>>> Expected Output: Nothing
+```
+
+## Selected (Short) Good Example Commands
 
 ```
 cmd (Push (I 4)) [] []
@@ -110,7 +161,6 @@ stmt (While Equ (S (Begin [Push (I 5),Push (I 2),E Add]))) [B True,B True] []
 >>> Expected Output: Just [I 7]
 ```
 
-
 #### ExtractTuple
 ```haskell
 cmd (ExtractTuple 0) [T (I 1) (I 2)] []
@@ -125,56 +175,4 @@ cmd (ExtractTuple 1) [T (I 1) (I 2)] []
 ```haskell
 cmd (ExtractTuple 2) [T (I 1) (I 2)] []
 >>> Expected Output: Just [I 1,I 2]
-```
-
-### Bad Program Examples and their Outputs
-```haskell
-expr Add [I 1,B True,I 2]
->>> Expected Output: Nothing
-```
-
-```haskell
-expr Mul [B False,I 1,I 2]
->>> Expected Output: Nothing
-```
-
-```haskell
-expr Div [I 5,I 0,I 1]
->>> Expected Output: Nothing
-```
-
-```haskell
-expr Div [I 5,B True,I 1]
->>> Expected Output: Nothing
-```
-
-```haskell
-expr Equ [B True,T (B False) (B True)]
->>> Expected Output: Nothing
-```
-
-```haskell
-expr (If [Push (I 5)] [Push (B False)]) [T (B True) (I 1)]
->>> Expected Output: Nothing
-```
-
-```haskell
-stmt (While Equ [Push (I 5),E Add]) [B True,I 4]
->>> Expected Output: Nothing
-```
-
-```haskell
-prog [E Add,E Equ] []
->>> Expected Output: Nothing
-```
-
-#### ExtractTuple
-```haskell
-cmd (ExtractTuple 5) [T (I 3) (I 4)] []
->>> Expected Output: Nothing
-```
-
-```haskell
-cmd (ExtractTuple 1) [B True,T (B False) (I 4)] []
->>> Expected Output: Nothing
 ```


### PR DESCRIPTION
Closes #20 

Added `mod` operation.

Edits to the `readme` (added example, removed all the short good examples since we'll be replacing them with larger ones, added a placeholder for hannah's good example).

Added a good example that deconstructs an integer into its digits. Covers these language features:
- Functions
- Functions as arguments
- Ints
- While
- Dup, Push, Mod, Swap, Div, Pop

I added a `run` function that wraps the `prog` function. Using `run` pulls in the standard library (which I'm calling "Mathlude") and is included in the top of the file. Factorial has been converted from syntactic sugar to a library-level feature, which is where I think it actually belongs (@HannahTierneyV it should be pretty easy to convert your `percent` sugar to a function as well, you just have to wrap it with `[ ]` and give it a name - see `factorial`.) Using `run` runs against an empty stack by default.