### PR TITLE
Added for loop syntactic sugar and environment variable counter

### DIFF
--- a/MathLang.hs
+++ b/MathLang.hs
@@ -6,8 +6,8 @@
 module MathLang where
 
 -- Our "Prelude", which contains library-level definitions
-mathlude :: [Func]
-mathlude = [("factorial", [S (Begin [Push (B False), Swap, E Dup, Push (I 2), 
+mathlude :: [Ref]
+mathlude = [RF ("factorial", [S (Begin [Push (B False), Swap, E Dup, Push (I 2), 
             S (While Less [E Dup, Push (I 1), minus, absval, E Dup, Push (I 2)]), 
             S (While IsType [E Mul]), Swap, Pop ])])
            ]
@@ -247,7 +247,7 @@ expr (IsType) q fs = case q of
                                                    _                  -> Just ((B False : q), fs)
 expr (Mod) q fs = case q of 
                         (I i : [])       -> Just ([I (1 `mod` i)], fs)
-                        (I i : I j : qs) -> Just (I ((j `mod` i) : qs), fs)
+                        (I i : I j : qs) -> Just ((I (j `mod` i) : qs), fs)
                         _                -> Nothing
 
 

--- a/MathLang.hs
+++ b/MathLang.hs
@@ -298,8 +298,7 @@ factorial = S (Begin [Push (B False), Swap, E Dup, Push (I 2),
 for :: Int -> [Cmd] -> Cmd
 for i c = S (Begin [Push (I i), Set, Push Counter, Push (I 0), S (While Less [Push Counter, dec, Set, S (Begin c), Push Counter, Push(I 0)])])
 
-
---summation :: Int -> [Cmd] -> Cmd
---summation i c= S(Begin [Push (I 0), Push (I 0), Push (I i),
---                While Less [E Dup, Push (I 0), E (If [E Equ] ]
---])
+summation :: Int -> Int -> [Cmd] -> Cmd
+summation l h c = S(Begin [Push (I l), Set, Push (I (h+1)), Push (I l), S (While Less 
+                   [Push Counter, S (Begin c), Push (I (h+1)), Push Counter, inc, Set, Push Counter]), 
+                   for (h-l) [E Add] ])


### PR DESCRIPTION
In order to implement a for loop, some form of counter external to the stack was required. This commit adds the `Counter` value, which can be set to the value at the top of the stack with the `Set` command.  The value of `Counter` is scoped by statement. `Counter` values are evaluated when used in expressions. 


For example, the program:
`run [Push (I 10), Set, Push (I 20), S (Begin [Set]), Push Counter, Push (I 0), E Add]  []`
will result in a final stack of `[I 10]` as while the counter was set to 20 in the Begin statement, that change went out of scope once the statement ended.

The `Counter` can be used without setting, and will default to 0. 

---

To run the `for` function, pass an integer and the commands to run to it.
For example:
 `run [for 5 [Push (I 10)]] []`
results in a stack of:
`[I 10, I 10, I 10, I 10, I 10]`

---

This also includes the `summation` implementation as syntactic sugar. 
While it could be possible to write summation as a library level function, I feel that this would be very user-unfriendly, as it would require that the user push two integers and a list of commands as a single value onto the stack. 

`summation` applies the provided commands to a range of values from a to b, then sums the result. It expects that the commands take a single parameter and result in a single value on the stack. For example: 
`run [summation 3 5 [E Dup, E Mul]] []` 
results in a final stack of `[I 50]` and is equivalent to
∑<sub>3</sub><sup>5</sup> x<sup>2</sup>
